### PR TITLE
remove unneeded sparkline files

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -151,6 +151,7 @@ function organizePackage() {
 	rm -rf vendor/tecnickcom/tcpdf/examples
 	rm -rf vendor/tecnickcom/tcpdf/CHANGELOG.txt
 	rm -rf vendor/guzzle/guzzle/docs/
+	rm -rf vendor/davaxi/sparkline/!(src|LICENSE)
 
 	# Delete un-used files from the matomo-icons repository
 	rm -rf plugins/Morpheus/icons/src*


### PR DESCRIPTION
Cleanup for https://github.com/matomo-org/matomo/pull/12066

Of course can can also list all files to delete:
```
vendor/davaxi/sparkline/autoload.php
vendor/davaxi/sparkline/composer.json
vendor/davaxi/sparkline/composer.travis.json
vendor/davaxi/sparkline/grumphp.yml
vendor/davaxi/sparkline/phpunit.xml
vendor/davaxi/sparkline/README.md
vendor/davaxi/sparkline/tests
```