### PR TITLE
Default installation requires php-mbstring

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: piwik
 Architecture: all
 Homepage: http://piwik.org
 Pre-Depends: debconf (>= 0.5.00) | debconf-2.0
-Depends: php5-cli (>= 5.5.9)|php7.0-cli, php5-mysql|php5-mysqlnd|php7.0-mysql, php5-curl|php7.0-curl, php5-gd|php7.0-gd, php-mbstring
+Depends: php5-cli (>= 5.5.9)|php7.0-cli, php5-mysql|php5-mysqlnd|php7.0-mysql, php5-curl|php7.0-curl, php5-gd|php7.0-gd, php5-cli|php-mbstring
 Recommends: logrotate, libapache2-mod-php5 (>= 5.3.3)|php5-cgi (>= 5.5.9)|php5-fpm (>= 5.5.9)|libapache2-mod-php7.0|php7.0-cgi|php7.0-fpm, php5-geoip|php7.0-geoip
 Suggests: mysql-server | mariadb-server, geoip-database-extra
 Description: leading Free/Libre open source Web Analytics software

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: piwik
 Architecture: all
 Homepage: http://piwik.org
 Pre-Depends: debconf (>= 0.5.00) | debconf-2.0
-Depends: php5-cli (>= 5.5.9)|php7.0-cli, php5-mysql|php5-mysqlnd|php7.0-mysql, php5-curl|php7.0-curl, php5-gd|php7.0-gd
+Depends: php5-cli (>= 5.5.9)|php7.0-cli, php5-mysql|php5-mysqlnd|php7.0-mysql, php5-curl|php7.0-curl, php5-gd|php7.0-gd, php-mbstring
 Recommends: logrotate, libapache2-mod-php5 (>= 5.3.3)|php5-cgi (>= 5.5.9)|php5-fpm (>= 5.5.9)|libapache2-mod-php7.0|php7.0-cgi|php7.0-fpm, php5-geoip|php7.0-geoip
 Suggests: mysql-server | mariadb-server, geoip-database-extra
 Description: leading Free/Libre open source Web Analytics software


### PR DESCRIPTION
After the installation of the package, the web interface requires the install of ```php-mbstring``` package. This PR adds the package as a dependance to matomo.

Screenshot:
![mbstring_error](https://user-images.githubusercontent.com/1708780/40373050-55c48e1a-5de6-11e8-987d-c94d68145ec3.png)

```/var/log/apt/history.log``` contains:

> Start-Date: 2018-05-18  17:25:57
> Commandline: apt install php-mbstring
> Requested-By: stephane (1002)
> Install: php7.0-mbstring:amd64 (7.0.27-0+deb9u1, automatic), php-mbstring:amd64 (1:7.0+49)
> End-Date: 2018-05-18  17:25:57



