### PR TITLE
Provides php-mbstring for every debian distribution

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: matomo
 Architecture: all
 Homepage: http://matomo.org
 Pre-Depends: debconf (>= 0.5.00) | debconf-2.0
-Depends: php5-cli (>= 5.5.9)|php-cli, php5-mysql|php5-mysqlnd|php-mysql, php5-curl|php-curl, php5-gd|php-gd
+Depends: php5-cli (>= 5.5.9)|php-cli, php5-mysql|php5-mysqlnd|php-mysql, php5-curl|php-curl, php5-gd|php-gd, php5-cli|php-mbstring
 Recommends: logrotate, libapache2-mod-php5 (>= 5.3.3)|php5-cgi (>= 5.5.9)|php5-fpm (>= 5.5.9)|libapache2-mod-php|php-cgi|php-fpm, php5-geoip|php-geoip
 Suggests: mariadb-server | mysql-server, geoip-database-extra, php-mbstring
 Description: Leading Free/Libre open source Web Analytics software


### PR DESCRIPTION
After the installation of the package, the web interface requires the install of php-mbstring package. This PR adds the package as a dependency to matomo.