### PR TITLE
install composer "the right way"

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -132,7 +132,18 @@ function die() {
 function organizePackage() {
 	if [ ! -f "composer.phar" ]
 	then
-		curl -sS https://getcomposer.org/installer | php  || die "Error installing composer "
+		EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+		php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+		ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+		if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+		then
+			>&2 echo 'ERROR: Invalid installer signature'
+			rm composer-setup.php
+			exit 1
+		fi
+		php composer-setup.php --quiet || die "Error installing composer "
+		rm composer-setup.php
 	fi
 	# --ignore-platform-reqs in case the building machine does not have one of the packages required ie. GD required by cpchart
 	php composer.phar install --no-dev -o --ignore-platform-reqs || die "Error installing composer packages"


### PR DESCRIPTION
It doesn't really matter, but it is a bit more secure to check the signature before installing composer as explained here:
https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md