### PR TITLE
prevent building stable version that has already been released

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -328,7 +328,7 @@ for F in $FLAVOUR; do
 	then
 		if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
 		then
-			die "Stable version $VERSION has already been build"
+			die "--> Error: stable version $VERSION has already been built (not expected). <-- "
 		fi
 	fi
 

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -324,7 +324,7 @@ for F in $FLAVOUR; do
 		BUILDING_LATEST_MAJOR_VERSION_STABLE_OR_BETA=0
 	fi
 
-	if [ ! "$(echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev' -i | wc -l)" -eq 1 ]
+	if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev' -i
 	then
 		if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
 		then

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -324,6 +324,14 @@ for F in $FLAVOUR; do
 		BUILDING_LATEST_MAJOR_VERSION_STABLE_OR_BETA=0
 	fi
 
+	if [ ! "$(echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev' -i | wc -l)" -eq 1 ]
+	then
+		if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
+		then
+			die "Stable version $VERSION has already been build"
+		fi
+	fi
+
 	echo -e "Proceeding..."
 	sleep 2
 


### PR DESCRIPTION
references https://github.com/matomo-org/matomo/issues/13380
fixes #78 

@aureq I feel like this probably breaks your debian build script if you build it after Matt published the release.