### PR TITLE
Use apache-maintscripts-helper if available

### DIFF
--- a/debian/matomo.postinst
+++ b/debian/matomo.postinst
@@ -54,21 +54,20 @@ then
 fi
 
 # debian 8 and above
-if [ -d "/etc/apache2/conf-available" ]
+if [ -e /usr/share/apache2/apache2-maintscript-helper ];
 then
+	. /usr/share/apache2/apache2-maintscript-helper
 	if [ -e "/etc/apache2/conf.d/matomo.conf" -a ! -e "/etc/apache2/conf-available/matomo.conf" ];
 	then
 		echo "  * Migrating previous '/etc/apache2/conf.d/matomo.conf' to '/etc/apache2/conf-available/matomo.conf'"
 		mv /etc/apache2/conf.d/matomo.conf /etc/apache2/conf-available/matomo.conf
 		# the conf is enabled since it was debian 7 default behavior
-		a2enconf --maintmode matomo
-		invoke-rc.d apache2 reload 2>/dev/null || true
+		apache2_invoke enconf matomo.conf || exit $?
 	else
 		if [ ! -e /etc/apache2/conf-available/matomo.conf ];
 		then
 			ln -s /etc/matomo/apache.conf /etc/apache2/conf-available/matomo.conf
-			a2enconf --maintmode matomo
-			invoke-rc.d apache2 reload 2>/dev/null || true
+			apache2_invoke enconf matomo.conf || exit $?
 		fi
 		echo "  * Check Matomo web configuration in /etc/apache2/conf-available/matomo.conf"
 	fi

--- a/debian/matomo.postrm
+++ b/debian/matomo.postrm
@@ -18,14 +18,11 @@ then
 		invoke-rc.d apache2 reload 3>/dev/null || true
 	fi
 	
-	if [ -L /etc/apache2/conf-available/matomo.conf ];
+	if [ -e /usr/share/apache2/apache2-maintscript-helper ];
 	then
-		if [ -L /etc/apache2/conf-enabled/matomo.conf ];
-		then
-			a2disconf --maintmode matomo
-		fi			
+		. /usr/share/apache2/apache2-maintscript-helper
+		apache2_invoke disconf matomo.conf || exit $?
 		rm -f /etc/apache2/conf-available/matomo.conf
-		invoke-rc.d apache2 reload 3>/dev/null || true
 	fi			
 fi
 


### PR DESCRIPTION
Instead of directly calling a2enconf/a2disconf, use the maintscripts
helper provided by the Apache package if it is present, as per the
docs: https://wiki.debian.org/Apache/PackagingFor24

This fixes (#68) as it replaces the check for the apache config
directory which can be incorrect if other packages are installed that
include apache config files, such as php-fpm.