### PR TITLE
check if a2enconf exists in the postinst script

### DIFF
--- a/debian/matomo.postinst
+++ b/debian/matomo.postinst
@@ -54,7 +54,7 @@ then
 fi
 
 # debian 8 and above
-if [ -d "/etc/apache2/conf-available" ]
+if [ -d "/etc/apache2/conf-available" -a -x "/usr/sbin/a2enconf" ]
 then
 	if [ -e "/etc/apache2/conf.d/matomo.conf" -a ! -e "/etc/apache2/conf-available/matomo.conf" ];
 	then


### PR DESCRIPTION
I have a `/etc/apache2/conf-available` directory on my server, because it was created by default during the installation, but I have uninstalled the apache package itself, because I'm using Nginx as my web server. The `postinst` script however checks for the existence of that config directory and then assumes that Apache is installed and tries to run the `a2enconf` tool, which is not available on that machine.

So I've added a check to make sure that `/usr/sbin/a2enconf` actually exists and is executable before calling it.
