### PR TITLE
remove yml files from Matomo icons repo

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -199,6 +199,7 @@ function organizePackage() {
 	rm -rf plugins/Morpheus/icons/*.svg
 	rm -rf plugins/Morpheus/icons/*.txt
 	rm -rf plugins/Morpheus/icons/*.php
+	rm -rf plugins/Morpheus/icons/*.yml
 
 	# Delete un-used fonts
 	rm -rf vendor/tecnickcom/tcpdf/fonts/ae_fonts_2.0


### PR DESCRIPTION
I split the list of icons that there should not be a warning on travis for into a seperate file, so all *.yml files should also be deleted