### PR TITLE
Remove example plugins from release

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -200,6 +200,8 @@ function organizePackage() {
 	rm -rf plugins/Morpheus/icons/*.txt
 	rm -rf plugins/Morpheus/icons/*.php
 	rm -rf plugins/Morpheus/icons/*.yml
+	
+	rm -rf plugins/Example*
 
 	# Delete un-used fonts
 	rm -rf vendor/tecnickcom/tcpdf/fonts/ae_fonts_2.0


### PR DESCRIPTION
Problem is two example plugins are enabled by default in core. Not sure why. 
Removing them in https://github.com/matomo-org/matomo/pull/14991

Those example plugins are only meant for development and should not be included in a final release.

refs https://github.com/matomo-org/matomo-package/issues/101
