### PR TITLE
Remove docs from matomo zip

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -184,6 +184,11 @@ function organizePackage() {
 	rm -rf vendor/maxmind-db/reader/CHANGELOG.md
 	rm -rf vendor/maxmind/web-service-common/dev-bin/
 	rm -rf vendor/maxmind/web-service-common/CHANGELOG.md
+	rm -rf vendor/php-di/invoker/doc/
+	rm -rf vendor/szymach/c-pchart/doc
+	rm -rf vendor/leafo/lessphp/docs
+	rm -rf vendor/container-interop/container-interop/docs
+	rm -rf vendor/pear/archive_tar/docs
 
 	# Delete un-used files from the matomo-icons repository
 	rm -rf plugins/Morpheus/icons/src*


### PR DESCRIPTION
Won't help much in terms of reducing number of files or reducing the size but thought I create the PR anyway as I'm removing these files in Matomo for WordPress https://github.com/matomo-org/wp-matomo/pull/133/files#diff-eaa5cf986e41533e3c0ef48de0a35bd0R36

Will remove over 40 not needed markdown files...