### PR TITLE
Accept "php-mysqlnd" as a debian package dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: matomo
 Architecture: all
 Homepage: http://matomo.org
 Pre-Depends: debconf (>= 0.5.00) | debconf-2.0
-Depends: php5-cli (>= 5.5.9)|php-cli, php5-mysql|php5-mysqlnd|php-mysql, php5-curl|php-curl, php5-gd|php-gd, php5-cli|php-mbstring, php5-cli|php-simplexml
+Depends: php5-cli (>= 5.5.9)|php-cli, php5-mysql|php5-mysqlnd|php-mysql|php-mysqlnd, php5-curl|php-curl, php5-gd|php-gd, php5-cli|php-mbstring, php5-cli|php-simplexml
 Recommends: logrotate, libapache2-mod-php5 (>= 5.3.3)|php5-cgi (>= 5.5.9)|php5-fpm (>= 5.5.9)|libapache2-mod-php|php-cgi|php-fpm, php5-geoip|php-geoip
 Suggests: mariadb-server | mysql-server, geoip-database-extra, php-mbstring, libmaxminddb0
 Description: Leading Free/Libre open source Web Analytics software


### PR DESCRIPTION
When using alternate php source on debian (aka. https://deb.sury.org/ ) every `php*.*-mysql` package provides `php-mysqli` and  `php-mysqlnd` pseudo package and *NOT* `php-mysql`.

```
$ apt-cache show php7.2-mysql
Package: php7.2-mysql
Source: php7.2
Version: 7.2.31-1+0~20200514.41+debian9~1.gbpe2a56b
Architecture: amd64
Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
Installed-Size: 447
Depends: php-common (>= 1:73), ucf, php7.2-common (= 7.2.31-1+0~20200514.41+debian9~1.gbpe2a56b), libc6 (>= 2.15)
Provides: php-mysqli, php-mysqlnd, php-pdo-mysql, php7.2-mysqli, php7.2-mysqlnd, php7.2-pdo-mysql
Homepage: http://www.php.net/
Priority: optional
Section: php
Filename: pool/main/p/php7.2/php7.2-mysql_7.2.31-1+0~20200514.41+debian9~1.gbpe2a56b_amd64.deb
Size: 116900
SHA256: c2a122776dc6c1f1b183e9a046f25c14a3ffaf6f5495594717546f3d0daf5250
SHA1: c673e21f7d5c573e3d70dbb100355c04816f318c
MD5sum: 9a3caa3c9c3e9b05e7b4ff934d66d066
Description: MySQL module for PHP
 This package provides the MySQL module(s) for PHP.
 .
 PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used
 open source general-purpose scripting language that is especially suited
 for web development and can be embedded into HTML.
Description-md5: dba46097413040653c65df244b4f891f
```

So is the default debian php mysql package (here on stretch)
```
$ apt-cache show php7.0-mysql
Package: php7.0-mysql
Source: php7.0
Version: 7.0.33-29+0~20200514.36+debian9~1.gbp126f6f
Architecture: amd64
Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
Installed-Size: 479
Depends: php-common (>= 1:73), ucf, php7.0-common (= 7.0.33-29+0~20200514.36+debian9~1.gbp126f6f), libc6 (>= 2.15)
Provides: php-mysqli, php-mysqlnd, php-pdo-mysql, php7.0-mysqli, php7.0-mysqlnd, php7.0-pdo-mysql
Homepage: http://www.php.net/
Priority: optional
Section: php
Filename: pool/main/p/php7.0/php7.0-mysql_7.0.33-29+0~20200514.36+debian9~1.gbp126f6f_amd64.deb
Size: 123872
SHA256: db9eefdae08c65dc6fa284efe34bb07047e96cd2020c4e4c14e5ae86a141046c
SHA1: 8b654490bd0a2e212e01e42a5c3a885063bb9675
MD5sum: 8246d96f31f455a76d234b75dd83b566
Description-en: MySQL module for PHP
 This package provides the MySQL module(s) for PHP.
 .
 PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used
 open source general-purpose scripting language that is especially suited
 for web development and can be embedded into HTML.
Description-md5: dba46097413040653c65df244b4f891f

Package: php7.0-mysql
Source: php7.0
Version: 7.0.33-0+deb9u7
Installed-Size: 478
Maintainer: Debian PHP Maintainers <pkg-php-maint@lists.alioth.debian.org>
Architecture: amd64
Provides: php-mysqli, php-mysqlnd, php-pdo-mysql, php7.0-mysqli, php7.0-mysqlnd, php7.0-pdo-mysql
Depends: php-common (>= 1:35), ucf, php7.0-common (= 7.0.33-0+deb9u7), libc6 (>= 2.15)
Description-en: MySQL module for PHP
 This package provides the MySQL module(s) for PHP.
 .
 PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used
 open source general-purpose scripting language that is especially suited
 for web development and can be embedded into HTML.
Description-md5: dba46097413040653c65df244b4f891f
Homepage: http://www.php.net/
Section: php
Priority: optional
Filename: pool/updates/main/p/php7.0/php7.0-mysql_7.0.33-0+deb9u7_amd64.deb
Size: 124010
MD5sum: 732e3828f4d8b064351ec46c4eae42f7
SHA1: 718b268506712f6cf2fb8656987c97de1f81caaf
SHA256: 02514282c9fb94a083b5d133b9f9f3844850dab7e1b37fc4b57a13d8f2daa8e0
```
