### PR TITLE
Ship Matomo with Provider and Custom Variables plugin

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -29,7 +29,7 @@ REMOTE_LOGIN="piwik-builds"
 REMOTE_HTTP_PATH="/home/piwik-builds/www/builds.piwik.org"
 
 # List of Sub-modules that SHOULD be in the packaged release, eg PiwikTracker|CorePluginName
-SUBMODULES_PACKAGED_WITH_CORE='log-analytics|plugins/Morpheus/icons|plugins/TagManager'
+SUBMODULES_PACKAGED_WITH_CORE='log-analytics|plugins/Morpheus/icons|plugins/TagManager|plugins/Provider|plugins/CustomVariables'
 
 REMOTE="${REMOTE_LOGIN}@${REMOTE_SERVER}"
 REMOTE_CMD="ssh -C ${REMOTE}"


### PR DESCRIPTION
For say 6 months or 1 year we should include Provider and Custom Variables plugin still in Matomo 4.X so there are no complications when upgrading. We won't enable them though by default. Once most users have updated to Matomo 4 (in 6 months or 1 year), we could stop shipping it with the release. 

For people that update from the most recent 3.14.1 version it will update the plugins through the marketplace anyway. For other users updating from an older version it will show an update is available because of https://github.com/matomo-org/matomo/pull/16323 but the plugins will be deactivated by core when updating and the admin has to activate them again.

I reckon it be good to still ship it with Matomo at least for a few months simply to prevent possible issues where the plugins would be otherwise deactivated or not updated.

Refs