### PR TITLE
Remove /vendor/bin directory from build

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -170,6 +170,7 @@ function organizePackage() {
 	echo -e "Deleting un-needed files..."
 
 	rm -rf composer.phar
+	rm -rf vendor/bin/
 	rm -rf vendor/twig/twig/test/
 	rm -rf vendor/twig/twig/doc/
 	rm -rf vendor/symfony/console/Symfony/Component/Console/Resources/bin


### PR DESCRIPTION
wikimedia/less.php places `lessc` in the `bin` directory. Should be save removing it, as we don't use it at all.

refs https://github.com/matomo-org/matomo/issues/16938