### PR TITLE
Update c-pchart excludes after update

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -227,14 +227,14 @@ function organizePackage() {
 	rm -rf vendor/tecnickcom/tcpdf/fonts/times*
 	rm -rf vendor/tecnickcom/tcpdf/fonts/uni2cid*
 
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/advent_light*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Bedizen*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/calibri*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Forgotte*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/MankSans*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/pf_arma_five*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Silkscreen*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/verdana*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/advent_light*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/Bedizen*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/calibri*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/Forgotte*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/MankSans*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/pf_arma_five*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/Silkscreen*
+	rm -rf vendor/szymach/c-pchart/resources/fonts/verdana*
 	
 	rm -rf package-lock.json
 	

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -227,14 +227,15 @@ function organizePackage() {
 	rm -rf vendor/tecnickcom/tcpdf/fonts/times*
 	rm -rf vendor/tecnickcom/tcpdf/fonts/uni2cid*
 
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/advent_light*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/Bedizen*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/calibri*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/Forgotte*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/MankSans*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/pf_arma_five*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/Silkscreen*
-	rm -rf vendor/szymach/c-pchart/src/Resources/fonts/verdana*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/advent_light*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Bedizen*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/calibri*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Forgotte*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/GeosansLight*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/MankSans*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/pf_arma_five*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Silkscreen*
+	rm -rf vendor/szymach/c-pchart/src/resources/fonts/verdana*
 	
 	rm -rf package-lock.json
 	

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -231,7 +231,6 @@ function organizePackage() {
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Bedizen*
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/calibri*
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Forgotte*
-	rm -rf vendor/szymach/c-pchart/src/resources/fonts/GeosansLight*
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/MankSans*
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/pf_arma_five*
 	rm -rf vendor/szymach/c-pchart/src/resources/fonts/Silkscreen*

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -180,7 +180,6 @@ function organizePackage() {
 	rm -rf vendor/maxmind/web-service-common/dev-bin/
 	rm -rf vendor/maxmind/web-service-common/CHANGELOG.md
 	rm -rf vendor/php-di/invoker/doc/
-	rm -rf vendor/szymach/c-pchart/doc
 	rm -rf vendor/leafo/lessphp/docs
 	rm -rf vendor/container-interop/container-interop/docs
 	rm -rf vendor/pear/archive_tar/docs


### PR DESCRIPTION
c-pchart upgrade changed a few paths so fonts are no longer being excluded. This PR fixes those broken paths.